### PR TITLE
Fix default email bug

### DIFF
--- a/src/main/java/com/orbithy/cms/service/UserService.java
+++ b/src/main/java/com/orbithy/cms/service/UserService.java
@@ -48,9 +48,6 @@ public class UserService {
         }
         String SDUId = user.getSDUId();
         String password = user.getPassword();
-        if (user.getEmail() == null) {
-            user.setEmail("汉族");
-        }
         if (user.getNation() == null) {
             user.setNation("China");
         }


### PR DESCRIPTION
## Summary
- remove incorrect default email value in `UserService`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6841e213cf708330bf361a750d31203a